### PR TITLE
Removing loop dependency to solve "Require cycles are allowed, but can result in uninitialized values" error

### DIFF
--- a/components/ControlBar.js
+++ b/components/ControlBar.js
@@ -2,7 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { StyleSheet, View } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
-import { ToggleIcon, Time, Scrubber } from './'
+import { ToggleIcon } from './ToggleIcon'
+import { Time } from './Time'
+import { Scrubber } from './Scrubber'
 
 const styles = StyleSheet.create({
   container: {

--- a/components/Controls.js
+++ b/components/Controls.js
@@ -6,13 +6,11 @@ import {
   StyleSheet,
   TouchableWithoutFeedback as Touchable
 } from 'react-native'
-import {
-  PlayButton,
-  ControlBar,
-  Loading,
-  TopBar,
-  ProgressBar
-} from './'
+import { PlayButton } from './PlayButton'
+import { ControlBar } from './ControlBar'
+import { Loading } from './Loading'
+import { TopBar } from './TopBar'
+import { ProgressBar } from './ProgressBar'
 
 const styles = StyleSheet.create({
   container: {

--- a/components/TopBar.js
+++ b/components/TopBar.js
@@ -9,7 +9,7 @@ import {
 } from 'react-native'
 
 import LinearGradient from 'react-native-linear-gradient'
-import { ToggleIcon } from './'
+import { ToggleIcon } from './ToggleIcon'
 import { checkSource } from './utils'
 
 const backgroundColor = 'transparent'

--- a/components/Video.js
+++ b/components/Video.js
@@ -15,7 +15,7 @@ import VideoPlayer from 'react-native-video'
 import KeepAwake from 'react-native-keep-awake'
 import Orientation from 'react-native-orientation'
 import Icons from 'react-native-vector-icons/MaterialIcons'
-import { Controls } from './'
+import { Controls } from './Controls'
 import { checkSource } from './utils'
 const Win = Dimensions.get('window')
 const backgroundColor = '#000'


### PR DESCRIPTION
Solving the following problem:

```
Require cycle: node_modules/react-native-af-video-player/components/Video.js -> node_modules/react-native-af-video-player/components/index.js -> node_modules/react-native-af-video-player/components/Video.js

Require cycles are allowed, but can result in uninitialized values. Consider refactoring to remove the need for a cycle.
```
